### PR TITLE
Bump versions of Python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,10 +17,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------
 
-googleapis-common-protos==1.52.0
-grpcio==1.39.0
-grpcio-tools==1.39.0
+googleapis-common-protos==1.65.0
+grpcio==1.66.1
+grpcio-tools==1.66.1
 nose2[coverage_plugin]
-protobuf==3.17.3
+protobuf==5.28.1
 
 # [EOF]

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,10 @@ setup(
     packages = find_packages(where="python"),
     package_dir = {"": "python"},
     install_requires = [
-        "grpcio==1.39.0",
-        "protobuf==3.17.3",
-        "grpcio-tools==1.39.0",
-        "googleapis-common-protos==1.52.0"
+        "grpcio==1.66.1",
+        "protobuf==5.28.1",
+        "grpcio-tools==1.66.1",
+        "googleapis-common-protos==1.65.0"
     ],
     include_package_data=True,
 )


### PR DESCRIPTION
For an internal testing application we are using Python to talk to the OpenOLT agent. With this change voltha-protos is (again) installable via pip3 on Ubuntu 24.04.

Probably this patch is not relevant of the Voltha project but it would be helpful to us if it can be included.

Thanks!