### PR TITLE
Fix py version, add manual trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,9 +7,7 @@ on:
     # Only invoked on release tag pushes
     tags:
       - v*.*.*
-
-env:
-  python-version: 3.10
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -23,7 +21,7 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
-          python-version: ${{ env.python-version }}
+          python-version: "3.10"
 
       - name: Build package distribution files
         uses: opencord/shared-workflows/.github/actions/pypi-publish-action@main


### PR DESCRIPTION
GHA was getting "3.1" from the env var. This looks like it's due to the value being interpreted as a float, with the trailing zero stripped. The value has been quoted so that it will be interpreted as a string, and also moved out of the unnecessary env var passing.

The manual trigger will allow re-running the action if there is an issue upon the initial tag push (as was the case with the current latest tag).